### PR TITLE
CarCollisionDetector exception fixed

### DIFF
--- a/src/AutomatedCar/App.xaml.cs
+++ b/src/AutomatedCar/App.xaml.cs
@@ -149,7 +149,6 @@ namespace AutomatedCar
             controlledCar.Geometries.Add(controlledCar.Geometry);
             controlledCar.RotationPoint = new System.Drawing.Point(54, 120);
             controlledCar.Rotation = rotation;
-            controlledCar.CarCollisionDetector = new SystemComponents.CarCollisionDetector(controlledCar.VirtualFunctionBus);
 
             controlledCar.Start();
 

--- a/src/AutomatedCar/Models/AutomatedCar.cs
+++ b/src/AutomatedCar/Models/AutomatedCar.cs
@@ -18,6 +18,8 @@ namespace AutomatedCar.Models
         private Sensor radarSensor;
         
         private Sensor cameraSensor;
+
+        private CarCollisionDetector carCollisionDetector;
         
         private PowertrainManager powertrainManager;
 
@@ -30,6 +32,9 @@ namespace AutomatedCar.Models
         public AutomatedCar(int x, int y, string filename)
             : base(x, y, filename)
         {
+            this.Collideable = true;
+            this.WorldObjectType = WorldObjectType.Car;
+
             this.virtualFunctionBus = new VirtualFunctionBus();
             this.radarSensor = new Radar(this.virtualFunctionBus);
             this.cameraSensor = new Camera(this.virtualFunctionBus);
@@ -41,8 +46,6 @@ namespace AutomatedCar.Models
         }
 
         public VirtualFunctionBus VirtualFunctionBus { get => this.virtualFunctionBus; }
-
-        public CarCollisionDetector CarCollisionDetector { get; set; }
 
         public int Revolution { get; set; }
 

--- a/src/AutomatedCar/SystemComponents/CarCollisionDetector.cs
+++ b/src/AutomatedCar/SystemComponents/CarCollisionDetector.cs
@@ -19,13 +19,22 @@
         {
             this.packet = new CollisionPacket();
             virtualFunctionBus.CollisionPacket = packet;
-            this.collidableWorldObjects = World.Instance.WorldObjects
-                .Where(obj => obj.Collideable &&
-                obj != World.Instance.ControlledCar);
+        }
+
+        private void SetCollidableWorldObjectsIfNotSet()
+        {
+            if (this.collidableWorldObjects == null)
+            {
+                this.collidableWorldObjects = World.Instance.WorldObjects
+                    .Where(obj => obj.Collideable &&
+                    obj != World.Instance.ControlledCar);
+            }
         }
 
         public override void Process()
         {
+            this.SetCollidableWorldObjectsIfNotSet();
+
             var collisions = this.collidableWorldObjects
                 .Where(obj => this.CollisionCheck(World.Instance.ControlledCar, obj));
 


### PR DESCRIPTION
CarCollisionDetector threw an exception when the controlled car was null (first controlled car). Fixed here.